### PR TITLE
UI talking to server using HTTP2

### DIFF
--- a/blog/server/main.go
+++ b/blog/server/main.go
@@ -26,12 +26,14 @@ func main() {
 	dbClient := getMongoDbClient(ctx)
 	defer dbClient.Disconnect(ctx)
 
-	if consts.UseHttp1 {
+	if consts.NoProtoBuf {
 		server := SetupRouter()
 		log.Println("HTTP1 Server started")
-		server.Run(":4444")
+		certFile := "ssl/server.crt"
+		keyFile := "ssl/server.pem"
+		server.RunTLS(":4444", certFile, keyFile)
 	}
-	
+
 	listener := getListener()
 	defer listener.Close()
 

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -3,5 +3,5 @@ package consts
 const ClientUrl string = "localhost:4444"
 const ServerUrl string = "0.0.0.0:4444"
 const TCP string = "tcp" //  transport protocol
-const UseSSL bool = false //if we are using evans cli or HTTP1 then set this false
-const UseHttp1 = true
+const UseSSL bool = true //if we are using evans cli or HTTP1 then set this false
+const NoProtoBuf = true

--- a/reactClient/src/App.tsx
+++ b/reactClient/src/App.tsx
@@ -4,7 +4,7 @@ import "./App.css";
 
 import { useState, useEffect } from "react";
 
-const URL = "http://localhost:4444/ping"
+const URL = "https://localhost:4444/ping"
 function App() {
   const [time, setTime] = useState("")
 


### PR DESCRIPTION
Bit more research - the browser will automatically switch to http2 if is can. Http2 requires ssl by default
Updated gin config to require SSL and I can now see http requests in browser tools

![image](https://github.com/user-attachments/assets/f40f474a-4b4f-4e58-89c1-137f93f7bae0)

Renamed flag in const for accuracy.
Now need to get protobuf  working in React


